### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. The change introduces a cooldown period between pull requests for dependency updates.

* Added a `cooldown` section with `default-days: 7` to the `.github/dependabot.yml` file, ensuring Dependabot waits 7 days between opening new pull requests for updates.