### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-pico.yml
+++ b/.github/workflows/post-merge-pico.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'pico/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-vm-provisioning.yml
+++ b/.github/workflows/post-merge-vm-provisioning.yml
@@ -11,6 +11,8 @@ on:
       - release-*
     paths:
       - 'vm-provisioning/**'
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers to ensure that workflows are also triggered on tag creation, in addition to branch pushes and workflow dispatch events. This change improves automation coverage for releases and other tag-based events.

**Workflow trigger improvements:**

* [`.github/workflows/post-merge-pico.yml`](diffhunk://#diff-8870934233bd2004954c4dcc7a692ac5263f20e3aecc93a55ad896c638b868f7R14-R15): Added support for triggering the workflow on any tag pushed to the repository by including a wildcard pattern under `tags`.
* [`.github/workflows/post-merge-vm-provisioning.yml`](diffhunk://#diff-ca2d1152fae55b2b5815fffad2c2c6b286ef96c2afe279265a6fc1d3109abf93R14-R15): Similarly, added support for triggering the workflow on any tag by including a wildcard pattern under `tags`.
