### PR TITLE
Create security_scan_on_tag

### DIFF
--- a/.github/workflows/security_scan_on_tag
+++ b/.github/workflows/security_scan_on_tag
@@ -1,0 +1,33 @@
+---
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Security scan on tag
+
+on:
+  workflow_dispatch:
+  tags:
+      - '*'
+
+permissions:
+  contents: read
+
+jobs:
+  post-merge-pipeline:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
+    with:
+      run_build: false
+      run_docker_build: false
+      run_docker_push: false
+      run_helm_build: false
+      run_helm_push: false
+    secrets:
+      SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
+      NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}
+      NO_AUTH_ECR_PUSH_PASSWD: ${{ secrets.NO_AUTH_ECR_PUSH_PASSWD }}
+      MSTEAMS_WEBHOOK: ${{ secrets.TEAMS_WEBHOOK }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to perform a security scan whenever a tag is pushed or the workflow is manually triggered. The workflow leverages a shared pipeline and is configured to skip build and push steps, focusing solely on security scanning.

New security scanning workflow:

* Added `.github/workflows/security_scan_on_tag` to trigger a security scan on tag events or manual dispatch, using the shared `post-merge.yml` workflow with build and push steps disabled.
* Configured required permissions and secrets for the workflow, including security events and authentication tokens.