### PR TITLE
Update security-scan-on-tag.yml

### DIFF
--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@e1be8f090e3bb60af180bfac5ca32638517f9d1f
     with:
       run_build: false
       run_version_tag: false

--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -22,6 +22,7 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
     with:
       run_build: false
+      run_version_tag: false
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}

--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       run_build: false
       run_version_tag: false
+      run_repo_pipeline: false
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}

--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -22,10 +22,7 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
     with:
       run_build: false
-      run_docker_build: false
-      run_docker_push: false
-      run_helm_build: false
-      run_helm_push: false
+      run_version_tag: false
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}

--- a/.github/workflows/security-scan-on-tag.yml
+++ b/.github/workflows/security-scan-on-tag.yml
@@ -22,7 +22,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
     with:
       run_build: false
-      run_version_tag: false
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/security-scan-on-tag.yml` workflow to use a newer version of the shared `post-merge.yml` workflow and simplifies its configuration by removing unused build and push steps.

Workflow updates:

* Updated the referenced version of the shared workflow `post-merge.yml` to commit `e1be8f090e3bb60af180bfac5ca32638517f9d1f` for improved or fixed functionality.

Configuration simplification:

* Removed the `run_docker_build`, `run_docker_push`, `run_helm_build`, and `run_helm_push` inputs, and replaced them with `run_version_tag` and `run_repo_pipeline`, streamlining the workflow to only include relevant steps.